### PR TITLE
Integrate 3D DXF viewer into web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ AutoCAD DXF 파일을 분석하여 상세한 마크다운 리포트를 생성하
 ### 🖥️ 사용자 인터페이스
 - **GUI 버전**: tkinter 기반의 데스크톱 애플리케이션 (`dxf_analyzer_gui.py`)
 - **웹 버전**: Streamlit 기반의 웹 애플리케이션 (`dxf_analyzer_webapp.py`)
+    - 2D DXF 분석 기능
+    - 3D DXF 뷰어 통합 (별도 서버 `dxf_3d_visualizer.py` 실행 필요)
 - **CLI 버전**: 명령줄 인터페이스로 배치 처리 지원 (`dxf_analyzer.py`)
+- **3D 뷰어 서버**: FastAPI 및 Three.js 기반의 독립 실행형 3D DXF 뷰어 (`dxf_3d_visualizer.py`)
 - **Cloud API**: FastAPI 기반의 REST API 제공 (`dxf_cloud_api.py`)
     - DXF 파일 업로드 및 분석 요청 (기본, 고급, 3D 분석 옵션 제공)
     - JWT 기반 인증 (선택적)
@@ -61,7 +64,18 @@ python dxf_analyzer.py --gui
 
 #### 웹 버전
 ```bash
+# 1. 3D 뷰어 서버 실행 (필요시, 새 터미널에서)
+python dxf_3d_visualizer.py
+
+# 2. 웹 분석기 실행 (다른 터미널에서)
 python dxf_analyzer.py --web
+# 또는 streamlit run dxf_analyzer_webapp.py
+```
+
+#### 3D 뷰어 단독 실행
+```bash
+python dxf_3d_visualizer.py
+# 웹 브라우저에서 http://localhost:8080 (기본값)으로 접속
 ```
 
 #### CLI 버전
@@ -83,11 +97,15 @@ python dxf_analyzer.py --cli input_file.dxf -o custom_report.md
 5. "리포트 내보내기"로 마크다운 파일 저장
 
 ### 웹 버전 사용법
-1. 웹 브라우저에서 애플리케이션 접속
+1. 웹 브라우저에서 애플리케이션 접속 (기본: `http://localhost:8501`)
 2. 드래그 앤 드롭으로 DXF 파일 업로드
 3. 사이드바에서 분석 옵션 설정
 4. "분석 시작" 버튼 클릭
 5. 탭별로 결과 확인 및 다운로드
+   - **요약, 상세 정보, 마크다운, 다운로드**: 기존 2D 분석 결과
+   - **3D 뷰어**: 통합된 3D 뷰어 표시.
+     - 3D 뷰어 기능을 사용하려면 `dxf_3d_visualizer.py` 서버가 실행 중이어야 합니다. (기본: `http://localhost:8080`)
+     - 뷰어 내의 파일 선택 기능을 사용하여 DXF 파일을 로드하고 3D 모델을 확인합니다.
 
 ### CLI 버전 사용법
 ```bash

--- a/dxf_analyzer_webapp.py
+++ b/dxf_analyzer_webapp.py
@@ -127,9 +127,10 @@ if uploaded_file is not None:
                 status_text.text("완료!")
 
                 # 탭으로 결과 구분
-                tab1, tab2, tab3, tab4 = st.tabs(["📊 요약", "📋 상세 정보", "📝 마크다운", "💾 다운로드"])
+                tabs_list = ["📊 요약", "📋 상세 정보", "📝 마크다운", "💾 다운로드", "🧊 3D 뷰어"]
+                tab_summary, tab_details, tab_markdown, tab_download, tab_3d_viewer = st.tabs(tabs_list)
 
-                with tab1:
+                with tab_summary:
                     st.header("📊 분석 요약")
 
                     # 메트릭 표시
@@ -318,6 +319,36 @@ if uploaded_file is not None:
                             file_name=f"{os.path.splitext(uploaded_file.name)[0]}_data.json",
                             mime="application/json",
                             help="구조화된 JSON 형식으로 분석 데이터를 다운로드합니다"
+                        )
+
+                with tab_3d_viewer:
+                    st.header("🧊 3D 뷰어")
+                    st.markdown("DXF 파일을 3D로 시각화합니다. 아래 뷰어에서 파일을 선택하여 로드하세요.")
+                    st.markdown("⚠️ **참고:** 3D 뷰어 기능은 별도의 서버 실행이 필요할 수 있습니다. (`python dxf_3d_visualizer.py`)")
+
+                    # 3D 뷰어 iframe 설정
+                    # 로컬에서 dxf_3d_visualizer.py가 기본 포트 8080으로 실행 중이라고 가정
+                    viewer_url = "http://localhost:8080"
+
+                    # iframe 높이 조절
+                    iframe_height = st.slider("뷰어 높이 조절", min_value=400, max_value=1200, value=600, step=50)
+
+                    try:
+                        # iframe으로 3D 뷰어 임베드
+                        st.components.v1.iframe(viewer_url, height=iframe_height)
+                        st.success("3D 뷰어가 로드되었습니다. 뷰어 내에서 DXF 파일을 선택하여 3D 모델을 확인하세요.")
+                        st.info(
+                            "만약 뷰어가 제대로 표시되지 않는다면, 다음 사항을 확인해주세요:\n"
+                            "1. `dxf_3d_visualizer.py` 서버가 실행 중인지 확인하세요. (터미널에서 `python dxf_3d_visualizer.py` 실행)\n"
+                            "2. 서버가 다른 포트에서 실행 중이라면 `viewer_url`을 수정해야 합니다.\n"
+                            "3. 브라우저 콘솔(F12)에서 오류 메시지를 확인하세요."
+                        )
+                    except Exception as e:
+                        st.error(f"3D 뷰어를 로드하는 중 오류가 발생했습니다: {e}")
+                        st.warning(
+                            "다음 사항을 확인해주세요:\n"
+                            "1. `dxf_3d_visualizer.py` 서버가 실행 중인지 확인하세요. (터미널에서 `python dxf_3d_visualizer.py` 실행)\n"
+                            "2. 방화벽 설정이 3D 뷰어 서버의 포트(기본 8080) 접근을 허용하는지 확인하세요."
                         )
 
             else:


### PR DESCRIPTION
- Added a '3D Viewer' tab to the Streamlit web application.
- The 3D viewer is loaded via an iframe, sourcing from the `dxf_3d_visualizer.py` FastAPI server.
- Users need to run `dxf_3d_visualizer.py` separately (defaults to http://localhost:8080).
- Updated README.md with instructions for running and using the 3D viewer.